### PR TITLE
Fix HttpError (415) on login and adjust .gitignore rule for creds.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,8 @@ dmypy.json
 
 # pytype static type analyzer
 .pytype/
-jellyfin_cli/creds.json
+
+#generic-user1: updated creds.json gitignore rule 
+#to apply in any subdirectory, including the repository root
+creds.json
+*/creds.json

--- a/jellyfin_cli/jellyfin_client/JellyfinClient.py
+++ b/jellyfin_cli/jellyfin_client/JellyfinClient.py
@@ -43,7 +43,7 @@ class HttpClient:
 
     async def login(self, username, password):
         try:
-            res = await self.client.post(self.server+'/Users/authenticatebyname',data={
+            res = await self.client.post(self.server+'/Users/authenticatebyname',json={
                 "Username": username,
                 "Pw": password
             }, headers={


### PR DESCRIPTION
###  TL; DR

1. Fixed `HttpError` when logging into Jellyfin 10.7
2. Updated .gitignore rule for creds.json to apply globally in the repository

### Login Error

When attempting to log into Jellyfin Server 10.7.7 (and possibly other versions), Jellyfin-CLI would crash with an unhandled `HttpError`; specifically `415 Unsupported Media Type`.

More precisely, `HttpClient.login(username, password)` would encounter this error because when forming the POST to log in, credentials were passed using the generic `data` parameter of `aiohttp.ClientSession.post()`. Using the `json` parameter instead fixes the issue with very little effort.

### .gitignore changes

The .gitignore file for this repository has always included an entry for creds.json, but that entry only applied within a certain sub-directory of the project. However, creds.json appears to be created in the current working directory, wherever that may be. This could result in creds.json being accidentally included in the public repository. Replacing the old rule with rules that apply globally eliminates this issue. 
