### PR TITLE
Update request to create API key

### DIFF
--- a/jellyfin_cli/utils/play_utils.py
+++ b/jellyfin_cli/utils/play_utils.py
@@ -33,10 +33,10 @@ class Player:
         keys = await self._get_api_keys()
         if "jellyfin_cli_play" in keys:
             return keys["jellyfin_cli_play"]
-        else:    
-            await self.context.client.post("{}/Auth/Keys".format(self.context.url), data={
-                "App": "jellyfin_cli_play"
-            })
+        else:  
+            #NOTE: The app name MUST be specified as a query param.
+            #Jellyfin 10.7.7 WILL NOT accept the name as a POST payload. I have no idea why.
+            await self.context.client.post(f"{self.context.url}/Auth/Keys?app=jellyfin_cli_play")
             return await self._get_api_key()
 
     async def _delete_api_key(self, key=None):


### PR DESCRIPTION
I have two changes that are closely related. Both affect the `_get_api_key` method of `play_utils.Player`.

1.  The POST request to create a new API key for a play session was previously sending the application name in the payload of the request. However, Jellyfin server (tested version 10.7.7) expects the name as a URL query parameter. ([API doc](https://api.jellyfin.org/#operation/CreateKey))
This seems unusual to me but apparently that's the way it's supposed to be.

2. Debugging the above issue was made difficult by the use of recursion to re-send the request to create a key. Specifically, the error raised when every request to create an API key is unsuccessful was previously a `RecursionError`, which is not especially descriptive.
I have used a `for` loop to limit the number of requests sent, and added  a 1 second delay between each attempt. If each attempt is unsuccessful, `HttpError` is now raised rather than `RecursionError`. This isn't a necessary change for functionality, but might help with debugging in the future.