### PR TITLE
Update token verification when reading cached credentials

### DIFF
--- a/jellyfin_cli/jellyfin_client/JellyfinClient.py
+++ b/jellyfin_cli/jellyfin_client/JellyfinClient.py
@@ -149,3 +149,11 @@ class HttpClient:
             return r
         else:
             raise HttpError(await res.text())
+
+    #verifies that the login token is valid by running a request using it
+    #raises an HttpError if the token is invalid
+    async def test_token(self):
+
+        response = await self.context.client.get(f"{self.server}/Users/Me")
+        if response.status != 200:
+            raise HttpError(await response.text())

--- a/jellyfin_cli/utils/login_helper.py
+++ b/jellyfin_cli/utils/login_helper.py
@@ -38,5 +38,5 @@ async def load_creds():
     with open("creds.json", "r") as f:
         dc = load(f)
         client = HttpClient(dc["url"], ServerContext(cfg=dc))
-        await client.get_views()
+        await client.test_token()
         return client


### PR DESCRIPTION
This change affects the `login_helper.load_creds` method. It also adds a new method, `test_token`, to `JellyfinClient.HttpClient`.

The call to `get_views` used in the `load_creds` method was not a reliable way of validating a token. This meant that when a token was invalid, it was possible for an unhanded exception in `App._draw_home` to result, rather than the intended outcome (prompting user to re-enter credentials).

To solve this, I have added a dedicated `test_token` method to `JellyfinClient.HttpClient` that validates the current login token by submitting a request to the `/Users/Me` endpoint and checking the response status code. I have also replaced use of `get_views` with this new `test_token` method when reading cached credentials. After these changes, the user is now prompted to re-enter their credentials as intended.


 